### PR TITLE
Update v3.28.0

### DIFF
--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -52,8 +52,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libgweather/3.26/libgweather-3.26.0.tar.xz",
-                    "sha256": "5b84badc0b3ecffff5db1bb9a7cc4dd4e400a8eb3f1282348f8ee6ba33626b6e"
+                    "url": "https://download.gnome.org/sources/libgweather/3.28/libgweather-3.28.0.tar.xz",
+                    "sha256": "594be78dcc0b4c48bf79cd42ea6768160b661bc2a74d9d35ecc742575416e18f"
                 }
             ]
         },
@@ -63,8 +63,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/3.26/gnome-desktop-3.26.1.tar.xz",
-                    "sha256": "92fa697af986fb2c6bc6595f0155c968c17e5d1981a50584ff4fb6fd60124e2f"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/3.28/gnome-desktop-3.28.0.tar.xz",
+                    "sha256": "f1df71c39e32147f6d58f53a9c05b964b00b7c98fbca090419355437c72fd59d"
                 }
             ]
         },

--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.clocks",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.28",
     "branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-clocks",
@@ -84,8 +84,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-clocks/3.26/gnome-clocks-3.26.0.tar.xz",
-                    "sha256": "0f30a0260e73c8c2925fb24b6abca0ad65f3021d695c42d74ccb2f18225e4501"
+                    "url": "https://download.gnome.org/sources/gnome-clocks/3.28/gnome-clocks-3.28.0.tar.xz",
+                    "sha256": "d48e0bd0479b575adfc7beaa7cd9088258ee27142ab6305915a92cc8761aa7b5"
                 }
             ]
         }


### PR DESCRIPTION
gnome-clocks 3.28.0
===================

 * Search: workaround crash due to libgweather serialization
 * Updated translations