### PR TITLE
Enable Pulseaudio

### DIFF
--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -11,6 +11,8 @@
         "--share=ipc", "--socket=x11",
         /* Wayland access */
         "--socket=wayland",
+        /* Pulseaudio access for alarms */
+        "--socket=pulseaudio",
         /* Needs to talk to the network: */
         "--share=network",
         /* Needed to get geo-positioning */


### PR DESCRIPTION
Without Pulseaudio access alarms and timers will only display a notification when finished.