### PR TITLE
GNOME runtime 41, use libcanberra from shared-modules

### DIFF
--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -24,6 +24,7 @@
                 "*.la", "*.a"],
     "modules": [
         "shared-modules/intltool/intltool-0.51.json",
+        "shared-modules/libcanberra/libcanberra.json",
         {
             "name": "geocode-glib",
             "buildsystem": "meson",
@@ -58,36 +59,20 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/40/gnome-desktop-40.0.tar.xz",
-                    "sha256": "20abfd3f831e4e8092b55839311661dc73b2bf13fc9bef71c4a5a4475da9ee04"
+                    "url": "https://download.gnome.org/sources/gnome-desktop/41/gnome-desktop-41.0.tar.xz",
+                    "sha256": "69cb1d3d9a10700eb66348ef1c0e66a855fc5a97ae62902df97a499da11562d2"
                 }
             ]
         },
         {
             "name": "gsound",
+            "buildsystem": "meson",
             "cleanup": ["/bin"],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gsound/1.0/gsound-1.0.2.tar.xz",
-                    "sha256": "bba8ff30eea815037e53bee727bbd5f0b6a2e74d452a7711b819a7c444e78e53"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "libcanberra",
-                    "sources": [
-                        {
-                            "type": "archive",
-                            "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
-                            "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
-                        }
-                    ],
-                    "config-opts": [
-                        "--disable-alsa",
-                        "--disable-null",
-                        "--disable-oss"
-                    ]
+                    "url": "https://download.gnome.org/sources/gsound/1.0/gsound-1.0.3.tar.xz",
+                    "sha256": "ca2d039e1ebd148647017a7f548862350bc9af01986d39f10cfdc8e95f07881a"
                 }
             ]
         },

--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.clocks",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-clocks",
     "finish-args": [


### PR DESCRIPTION
Updated GNOME runtime to 41, updated dependencies, used libcanberra from shared-modules.