### PR TITLE
libgweather: Set version-scheme to odd-minor

### DIFF
--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -69,6 +69,7 @@
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "libgweather",
+                        "version-scheme": "odd-minor-is-unstable",
                         "versions": {
                             "<": "40.0",
                             ">=": "4.0.0"


### PR DESCRIPTION
Copied from: https://github.com/flathub/org.gnome.Maps/pull/148/changes/d093ed410e559ef54243f031025de889c330d077