### PR TITLE
Small fixes related to the cleanup commands and sdk-extensions

### DIFF
--- a/org.gnome.clocks.json
+++ b/org.gnome.clocks.json
@@ -3,13 +3,6 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
-    "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.vala"
-    ],
-    "build-options": {
-        "prepend-path": "/usr/lib/sdk/vala/bin/",
-        "prepend-ld-library-path": "/usr/lib/sdk/vala/lib"
-    },
     "command": "gnome-clocks",
     "finish-args": [
         "--device=dri",
@@ -22,15 +15,11 @@
     ],
     "cleanup": [
         "/include",
+        "/lib/girepository-1.0",
         "/lib/pkgconfig",
         "/share/pkgconfig",
-        "/share/aclocal",
-        "/man",
-        "/share/man",
-        "/share/gtk-doc",
-        "/share/vala",
-        "*.la",
-        "*.a"
+        "/share/gir-1.0",
+        "/share/vala"
     ],
     "modules": [
         {


### PR DESCRIPTION
GNOME runtime version 49 already provides the `org.freedesktop.Sdk.Extension.vala` extension, hence declaring it again is not required; therefore, I removed the redundant declaration to reduce duplication.

The cleanup commands contain some generic folders that do not exist for this project, and miss some folders safe to remove from the Flatpak; therefore, I updated the cleanup commands to suit the project's needs.